### PR TITLE
Update meshx version in objio example

### DIFF
--- a/objio/Cargo.toml
+++ b/objio/Cargo.toml
@@ -10,7 +10,7 @@ name = "objiors"
 crate-type = ["staticlib"]
 
 [dependencies]
-meshx = { version = "0.2", features = ["io", "serde_all"] }
+meshx = { version = "0.3", features = ["io", "serde_all"] }
 hdkrs = { path = "../hdkrs" }
 cxx = "1.0"
 


### PR DESCRIPTION
I had an issue with Rust complaining about multiple versions of meshx existing, and this fixed this issue.

By the way, I could not get the debug version of objio to compile on Windows. I got these linking errors when creating the .lib file
```
objiors.lib(mesh.obj) : error LNK2019: unresolved external symbol "__declspec(dllimport) int `public: char const * __cdecl UT_StringRef::c_str
(void)const '::`4'::ignore" (__imp_?ignore@?3??c_str@UT_StringRef@@QEBAPEBDXZ@4HA) referenced in function "void __cdecl fill_point_attrib<sign
ed char,struct hdkrs::PointCloud,int>(class GU_Detail const &,class GA_AIFTuple const *,class GA_Attribute const *,unsigned __int64,unsigned _
_int64,class std::vector<bool,class std::allocator<bool> > const &,struct hdkrs::PointCloud *)" (??$fill_point_attrib@CUPointCloud@hdkrs@@H@@Y
AXAEBVGU_Detail@@PEBVGA_AIFTuple@@PEBVGA_Attribute@@_K3AEBV?$vector@_NV?$allocator@_N@std@@@std@@PEAUPointCloud@hdkrs@@@Z) [C:\<my_local_path>\rep
os\hdkrs\objio\hdk\build_debug\objiohdk.vcxproj]
objiors.lib(mesh.obj) : error LNK2019: unresolved external symbol "__declspec(dllimport) int `public: __int64 __cdecl GA_IndexMap::offsetFromI
ndex(__int64)const '::`4'::ignore" (__imp_?ignore@?3??offsetFromIndex@GA_IndexMap@@QEBA_J_J@Z@4HA) referenced in function "void __cdecl hdkrs:
:update_points(class GU_Detail &,struct hdkrs::PointCloud const &)" (?update_points@hdkrs@@YAXAEAVGU_Detail@@AEBUPointCloud@1@@Z) [C:\Users\je
sse\repos\hdkrs\objio\hdk\build_debug\objiohdk.vcxproj]
objiors.lib(mesh.obj) : error LNK2019: unresolved external symbol "__declspec(dllimport) int `public: __int64 __cdecl GA_IndexMap::offsetFromI
ndex(__int64)const '::`10'::ignore" (__imp_?ignore@?9??offsetFromIndex@GA_IndexMap@@QEBA_J_J@Z@4HA) referenced in function "void __cdecl hdkrs
::update_points(class GU_Detail &,struct hdkrs::PointCloud const &)" (?update_points@hdkrs@@YAXAEAVGU_Detail@@AEBUPointCloud@1@@Z) [C:\Users\j
esse\repos\hdkrs\objio\hdk\build_debug\objiohdk.vcxproj]
objiors.lib(mesh.obj) : error LNK2019: unresolved external symbol "__declspec(dllimport) int `public: __int64 __cdecl GA_IndexMap::indexFromOf
fset(__int64)const '::`4'::ignore" (__imp_?ignore@?3??indexFromOffset@GA_IndexMap@@QEBA_J_J@Z@4HA) referenced in function "class rust::cxxbrid
ge1::Box<struct hdkrs::PointCloud> __cdecl hdkrs::build_pointcloud(class GU_Detail const &)" (?build_pointcloud@hdkrs@@YA?AV?$Box@UPointCloud@
hdkrs@@@cxxbridge1@rust@@AEBVGU_Detail@@@Z) [C:\<my_local_path>\repos\hdkrs\objio\hdk\build_debug\objiohdk.vcxproj]
objiors.lib(mesh.obj) : error LNK2019: unresolved external symbol "__declspec(dllimport) int `public: __int64 __cdecl GA_IndexMap::indexFromOf
fset(__int64)const '::`13'::ignore" (__imp_?ignore@?N@??indexFromOffset@GA_IndexMap@@QEBA_J_J@Z@4HA) referenced in function "class rust::cxxbr
idge1::Box<struct hdkrs::PointCloud> __cdecl hdkrs::build_pointcloud(class GU_Detail const &)" (?build_pointcloud@hdkrs@@YA?AV?$Box@UPointClou
d@hdkrs@@@cxxbridge1@rust@@AEBVGU_Detail@@@Z) [C:\<my_local_path>\repos\hdkrs\objio\hdk\build_debug\objiohdk.vcxproj]
objiors.lib(mesh.obj) : error LNK2019: unresolved external symbol "__declspec(dllimport) int `public: __int64 __cdecl GA_ATITopology::getLink(
__int64)const '::`4'::ignore" (__imp_?ignore@?3??getLink@GA_ATITopology@@QEBA_J_J@Z@4HA) referenced in function "class std::tuple<class std::v
ector<bool,class std::allocator<bool> >,unsigned __int64> __cdecl mark_points_and_count_vertices<struct hdkrs::PolyMesh>(class GU_Detail const
 &)" (??$mark_points_and_count_vertices@UPolyMesh@hdkrs@@@@YA?AV?$tuple@V?$vector@_NV?$allocator@_N@std@@@std@@_K@std@@AEBVGU_Detail@@@Z) [C:\
<my_local_path>\repos\hdkrs\objio\hdk\build_debug\objiohdk.vcxproj]
objiors.lib(mesh.obj) : error LNK2019: unresolved external symbol "__declspec(dllimport) int `public: class GA_Primitive const * __cdecl GA_Pr
imitiveList::get(__int64)const '::`6'::ignore" (__imp_?ignore@?5??get@GA_PrimitiveList@@QEBAPEBVGA_Primitive@@_J@Z@4HA) referenced in function
 "void __cdecl fill_prim_attrib<signed char,struct hdkrs::PolyMesh,int>(class GU_Detail const &,class GA_AIFTuple const *,class GA_Attribute c
onst *,unsigned __int64,unsigned __int64,struct hdkrs::PolyMesh *)" (??$fill_prim_attrib@CUPolyMesh@hdkrs@@H@@YAXAEBVGU_Detail@@PEBVGA_AIFTupl
e@@PEBVGA_Attribute@@_K3PEAUPolyMesh@hdkrs@@@Z) [C:\<my_local_path>\repos\hdkrs\objio\hdk\build_debug\objiohdk.vcxproj]
objiors.lib(mesh.obj) : error LNK2019: unresolved external symbol "__declspec(dllimport) int `private: static __int64 __cdecl GA_PrimitiveList
::getMyPrimPtrSize(class GA_Primitive * *)'::`4'::ignore" (__imp_?ignore@?3??getMyPrimPtrSize@GA_PrimitiveList@@CA_JPEAPEAVGA_Primitive@@@Z@4H
A) referenced in function "void __cdecl fill_prim_attrib<signed char,struct hdkrs::PolyMesh,int>(class GU_Detail const &,class GA_AIFTuple con
st *,class GA_Attribute const *,unsigned __int64,unsigned __int64,struct hdkrs::PolyMesh *)" (??$fill_prim_attrib@CUPolyMesh@hdkrs@@H@@YAXAEBV
GU_Detail@@PEBVGA_AIFTuple@@PEBVGA_Attribute@@_K3PEAUPolyMesh@hdkrs@@@Z) [C:\<my_local_path>\repos\hdkrs\objio\hdk\build_debug\objiohdk.vcxproj]
objiors.lib(mesh.obj) : error LNK2019: unresolved external symbol "__declspec(dllimport) int `public: __int64 __cdecl GA_Detail::vertexPoint(_
_int64)const '::`4'::ignore" (__imp_?ignore@?3??vertexPoint@GA_Detail@@QEBA_J_J@Z@4HA) referenced in function "class std::tuple<class std::vec
tor<bool,class std::allocator<bool> >,unsigned __int64> __cdecl mark_points_and_count_vertices<struct hdkrs::PolyMesh>(class GU_Detail const &
)" (??$mark_points_and_count_vertices@UPolyMesh@hdkrs@@@@YA?AV?$tuple@V?$vector@_NV?$allocator@_N@std@@@std@@_K@std@@AEBVGU_Detail@@@Z) [C:\<path_to_local>\repos\hdkrs\objio\hdk\build_debug\objiohdk.vcxproj]
objiors.lib(mesh.obj) : error LNK2019: unresolved external symbol "__declspec(dllimport) int `public: __int64 __cdecl GA_Primitive::getVertexO
ffset(__int64)const '::`4'::ignore" (__imp_?ignore@?3??getVertexOffset@GA_Primitive@@QEBA_J_J@Z@4HA) referenced in function "void __cdecl fill
_vertex_attrib<signed char,struct hdkrs::PolyMesh,int>(class GU_Detail const &,class GA_AIFTuple const *,class GA_Attribute const *,unsigned _
_int64,unsigned __int64,struct hdkrs::PolyMesh *)" (??$fill_vertex_attrib@CUPolyMesh@hdkrs@@H@@YAXAEBVGU_Detail@@PEBVGA_AIFTuple@@PEBVGA_Attri
bute@@_K3PEAUPolyMesh@hdkrs@@@Z) [C:\<my_local_path>\repos\hdkrs\objio\hdk\build_debug\objiohdk.vcxproj]
objiors.lib(mesh.obj) : error LNK2019: unresolved external symbol "__declspec(dllimport) int `public: __int64 __cdecl GA_PrimitiveList::getVer
texCount(__int64)const '::`4'::ignore" (__imp_?ignore@?3??getVertexCount@GA_PrimitiveList@@QEBA_J_J@Z@4HA) referenced in function "void __cdec
l fill_prim_attrib<signed char,struct hdkrs::PolyMesh,int>(class GU_Detail const &,class GA_AIFTuple const *,class GA_Attribute const *,unsign
ed __int64,unsigned __int64,struct hdkrs::PolyMesh *)" (??$fill_prim_attrib@CUPolyMesh@hdkrs@@H@@YAXAEBVGU_Detail@@PEBVGA_AIFTuple@@PEBVGA_Att
ribute@@_K3PEAUPolyMesh@hdkrs@@@Z) [C:\<my_local_path>\repos\hdkrs\objio\hdk\build_debug\objiohdk.vcxproj]
objiors.lib(mesh.obj) : error LNK2019: unresolved external symbol "__declspec(dllimport) int `public: __int64 __cdecl GA_PrimitiveList::getVer
texCount(__int64)const '::`16'::ignore" (__imp_?ignore@?BA@??getVertexCount@GA_PrimitiveList@@QEBA_J_J@Z@4HA) referenced in function "void __c
decl fill_prim_attrib<signed char,struct hdkrs::PolyMesh,int>(class GU_Detail const &,class GA_AIFTuple const *,class GA_Attribute const *,uns
igned __int64,unsigned __int64,struct hdkrs::PolyMesh *)" (??$fill_prim_attrib@CUPolyMesh@hdkrs@@H@@YAXAEBVGU_Detail@@PEBVGA_AIFTuple@@PEBVGA_
Attribute@@_K3PEAUPolyMesh@hdkrs@@@Z) [C:\<my_local_path>\repos\hdkrs\objio\hdk\build_debug\objiohdk.vcxproj]
objiors.lib(mesh.obj) : error LNK2019: unresolved external symbol "__declspec(dllimport) int `public: __int64 __cdecl GA_PrimitiveList::getVer
texOffset(__int64,__int64)const '::`4'::ignore" (__imp_?ignore@?3??getVertexOffset@GA_PrimitiveList@@QEBA_J_J0@Z@4HA) referenced in function "
void __cdecl fill_vertex_attrib<signed char,struct hdkrs::PolyMesh,int>(class GU_Detail const &,class GA_AIFTuple const *,class GA_Attribute c
onst *,unsigned __int64,unsigned __int64,struct hdkrs::PolyMesh *)" (??$fill_vertex_attrib@CUPolyMesh@hdkrs@@H@@YAXAEBVGU_Detail@@PEBVGA_AIFTu
ple@@PEBVGA_Attribute@@_K3PEAUPolyMesh@hdkrs@@@Z) [C:\<my_local_path>\repos\hdkrs\objio\hdk\build_debug\objiohdk.vcxproj]
objiors.lib(mesh.obj) : error LNK2019: unresolved external symbol "__declspec(dllimport) int `public: __int64 __cdecl GA_PrimitiveList::getVer
texOffset(__int64,__int64)const '::`16'::ignore" (__imp_?ignore@?BA@??getVertexOffset@GA_PrimitiveList@@QEBA_J_J0@Z@4HA) referenced in functio
n "void __cdecl fill_vertex_attrib<signed char,struct hdkrs::PolyMesh,int>(class GU_Detail const &,class GA_AIFTuple const *,class GA_Attribut
e const *,unsigned __int64,unsigned __int64,struct hdkrs::PolyMesh *)" (??$fill_vertex_attrib@CUPolyMesh@hdkrs@@H@@YAXAEBVGU_Detail@@PEBVGA_AI
FTuple@@PEBVGA_Attribute@@_K3PEAUPolyMesh@hdkrs@@@Z) [C:\<my_local_path>\repos\hdkrs\objio\hdk\build_debug\objiohdk.vcxproj]
objiors.lib(mesh.obj) : error LNK2019: unresolved external symbol "__declspec(dllimport) int `public: __int64 __cdecl GA_ListTypeRef<__int64,_
_int64,__int64>::trivialStart(void)const '::`4'::ignore" (__imp_?ignore@?3??trivialStart@?$GA_ListTypeRef@_J_J_J@@QEBA_JXZ@4HA) referenced in
function "void __cdecl fill_vertex_attrib<signed char,struct hdkrs::PolyMesh,int>(class GU_Detail const &,class GA_AIFTuple const *,class GA_A
ttribute const *,unsigned __int64,unsigned __int64,struct hdkrs::PolyMesh *)" (??$fill_vertex_attrib@CUPolyMesh@hdkrs@@H@@YAXAEBVGU_Detail@@PE
BVGA_AIFTuple@@PEBVGA_Attribute@@_K3PEAUPolyMesh@hdkrs@@@Z) [C:\<my_local_path>\repos\hdkrs\objio\hdk\build_debug\objiohdk.vcxproj]
objiors.lib(mesh.obj) : error LNK2019: unresolved external symbol "__declspec(dllimport) int `public: __int64 __cdecl GA_ListTypeRef<__int64,_
_int64,__int64>::get(__int64)const '::`4'::ignore" (__imp_?ignore@?3??get@?$GA_ListTypeRef@_J_J_J@@QEBA_J_J@Z@4HA) referenced in function "voi
d __cdecl fill_vertex_attrib<signed char,struct hdkrs::PolyMesh,int>(class GU_Detail const &,class GA_AIFTuple const *,class GA_Attribute cons
t *,unsigned __int64,unsigned __int64,struct hdkrs::PolyMesh *)" (??$fill_vertex_attrib@CUPolyMesh@hdkrs@@H@@YAXAEBVGU_Detail@@PEBVGA_AIFTuple
@@PEBVGA_Attribute@@_K3PEAUPolyMesh@hdkrs@@@Z) [C:\<my_local_path>\repos\hdkrs\objio\hdk\build_debug\objiohdk.vcxproj]
C:\<my_local_path>\Documents\houdini19.0\dso\objiohdk.dll : fatal error LNK1120: 16 unresolved externals [C:\<my_local_path>\repos\hdkrs\objio\hdk\bui
ld_debug\objiohdk.vcxproj]
```

I don't really think this could be related to the meshx change, but I don't understand all of this very well yet so I wanted to mention it